### PR TITLE
Fix Makefile to use full paths for Go tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-GOFUMPT ?= gofumpt
-GOLANGCI_LINT ?= golangci-lint
+GOFUMPT ?= $(HOME)/go/bin/gofumpt
+GOLANGCI_LINT ?= $(HOME)/go/bin/golangci-lint
 
 .PHONY: fmt lint check
 


### PR DESCRIPTION
## Summary

- Updates Makefile to use full paths (`$(HOME)/go/bin/`) for `gofumpt` and `golangci-lint`
- Ensures `make fmt` and `make lint` work regardless of PATH configuration
- Maintains ability to override tool paths via environment variables

## Problem

The Makefile currently assumes `gofumpt` and `golangci-lint` are in the user's PATH, which causes commands to fail if `~/go/bin` is not configured in the shell's PATH.

## Solution

Use `$(HOME)/go/bin/` prefix for tool paths while keeping the `?=` operator to allow users to override with their own custom paths if needed.

## Test Plan

- Installed go tools via `go install`
- Verified `make fmt` and `make lint` work without `~/go/bin` in PATH
- Confirmed tools can still be overridden: `GOFUMPT=/custom/path/gofumpt make fmt`

Fixes #2