### PR TITLE
Remove ineffectual assignment to foundFit in layout.go

### DIFF
--- a/internal/ui/layout.go
+++ b/internal/ui/layout.go
@@ -114,7 +114,6 @@ func (m *Model) updatePreviewDimensions(count int) {
 			selectedCols = cols
 			selectedWidth = innerWidth
 			selectedHeight = candidateHeight
-			foundFit = true
 			break
 		}
 	}


### PR DESCRIPTION
## Summary

Removes ineffectual assignment to `foundFit` variable that is immediately followed by a `break` statement.

## Problem

The linter flagged an ineffectual assignment at `internal/ui/layout.go:117` where `foundFit = true` is set but never used after the assignment since the code immediately breaks out of the loop.

## Solution

Removed the unused assignment as the variable serves no purpose after being set.

Fixes #5