### PR TITLE
Replace deprecated lipgloss Copy() calls in chrome.go

### DIFF
--- a/internal/ui/chrome.go
+++ b/internal/ui/chrome.go
@@ -33,7 +33,7 @@ func renderTitleBar(m *Model, width int) string {
 	base := lipgloss.NewStyle().
 		Foreground(lipgloss.Color("231")).
 		Background(lipgloss.Color("62"))
-	name := base.Copy().Bold(true).Padding(0, 2).Render("tmuxwatch")
+	name := base.Bold(true).Padding(0, 2).Render("tmuxwatch")
 
 	totalSessions := len(m.sessions)
 	staleCount := len(m.stale)
@@ -55,7 +55,7 @@ func renderTitleBar(m *Model, width int) string {
 	}
 	content := name
 	if len(metaParts) > 0 {
-		meta := base.Copy().
+		meta := base.
 			Padding(0, 2).
 			Foreground(lipgloss.Color("249")).
 			Render(strings.Join(metaParts, " • "))


### PR DESCRIPTION
## Summary

Replaces deprecated `lipgloss.Style.Copy()` method calls with direct style method chaining.

## Problem

The `lipgloss.Style.Copy()` method is deprecated. According to the deprecation notice, styles should be copied using simple assignment, and all methods already return a new style, making explicit copies unnecessary.

## Solution

Removed `.Copy()` calls at lines 36 and 58 in `internal/ui/chrome.go`, using direct method chaining instead since lipgloss style methods are immutable and return new instances.

Fixes #6