### PR TITLE
fix: eliminate races in tmux command tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Test
         run: go test ./...
 
+      - name: Race test
+        run: go test -race ./...
+
   lint:
     name: lint
     runs-on: ubuntu-latest
@@ -50,7 +53,7 @@ jobs:
           cache: true
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9.2.1
+        uses: golangci/golangci-lint-action@v9.3.0
         with:
           version: v2.12.2
           args: --timeout=5m

--- a/internal/tmux/client.go
+++ b/internal/tmux/client.go
@@ -10,29 +10,43 @@ import (
 	"time"
 )
 
-var (
-	execCommand = func(ctx context.Context, name string, args ...string) *exec.Cmd {
-		return exec.CommandContext(ctx, name, args...)
-	}
-	lookPath = exec.LookPath
-)
+type commandRunner func(context.Context, string, ...string) ([]byte, error)
+
+type pathLookup func(string) (string, error)
 
 // Client wraps a tmux binary path and exposes high-level snapshot helpers.
 type Client struct {
 	bin string
+	run commandRunner
 }
 
 // NewClient constructs a Client using the provided tmux binary. When tmuxPath
 // is empty, LookPath("tmux") is used so the system PATH controls discovery.
 func NewClient(tmuxPath string) (*Client, error) {
+	return newClient(tmuxPath, exec.LookPath)
+}
+
+func newClient(tmuxPath string, lookup pathLookup) (*Client, error) {
 	if tmuxPath == "" {
 		var err error
-		tmuxPath, err = lookPath("tmux")
+		tmuxPath, err = lookup("tmux")
 		if err != nil {
 			return nil, fmt.Errorf("tmux not found in PATH (install tmux >=3.1): %w", err)
 		}
 	}
-	return &Client{bin: tmuxPath}, nil
+	return &Client{bin: tmuxPath, run: runCommand}, nil
+}
+
+func runCommand(ctx context.Context, bin string, args ...string) ([]byte, error) {
+	return exec.CommandContext(ctx, bin, args...).Output()
+}
+
+func (c *Client) runTmux(ctx context.Context, args ...string) ([]byte, error) {
+	runner := c.run
+	if runner == nil {
+		runner = runCommand
+	}
+	return runner(ctx, c.bin, args...)
 }
 
 // Snapshot queries tmux for sessions, windows, and panes and returns a unified

--- a/internal/tmux/client_test.go
+++ b/internal/tmux/client_test.go
@@ -10,13 +10,9 @@ import (
 func TestNewClientMissingTmux(t *testing.T) {
 	t.Parallel()
 
-	oldLookPath := lookPath
-	lookPath = func(string) (string, error) {
+	_, err := newClient("", func(string) (string, error) {
 		return "", exec.ErrNotFound
-	}
-	t.Cleanup(func() { lookPath = oldLookPath })
-
-	_, err := NewClient("")
+	})
 	if err == nil {
 		t.Fatal("expected error when tmux is missing")
 	}
@@ -28,13 +24,10 @@ func TestNewClientMissingTmux(t *testing.T) {
 func TestListSessionsNoServer(t *testing.T) {
 	t.Parallel()
 
-	oldRun := runCommand
-	runCommand = func(context.Context, string, ...string) ([]byte, error) {
+	c := &Client{bin: "tmux", run: func(context.Context, string, ...string) ([]byte, error) {
 		return nil, &exec.ExitError{Stderr: []byte("failed to connect to server")}
-	}
-	t.Cleanup(func() { runCommand = oldRun })
+	}}
 
-	c := &Client{bin: "tmux"}
 	sessions, err := c.listSessions(context.Background())
 	if err != nil {
 		t.Fatalf("listSessions returned error: %v", err)
@@ -47,13 +40,10 @@ func TestListSessionsNoServer(t *testing.T) {
 func TestListWindowsNoServer(t *testing.T) {
 	t.Parallel()
 
-	oldRun := runCommand
-	runCommand = func(context.Context, string, ...string) ([]byte, error) {
+	c := &Client{bin: "tmux", run: func(context.Context, string, ...string) ([]byte, error) {
 		return nil, &exec.ExitError{Stderr: []byte("no server running")}
-	}
-	t.Cleanup(func() { runCommand = oldRun })
+	}}
 
-	c := &Client{bin: "tmux"}
 	windows, err := c.listWindows(context.Background())
 	if err != nil {
 		t.Fatalf("listWindows returned error: %v", err)
@@ -66,13 +56,10 @@ func TestListWindowsNoServer(t *testing.T) {
 func TestListPanesNoServer(t *testing.T) {
 	t.Parallel()
 
-	oldRun := runCommand
-	runCommand = func(context.Context, string, ...string) ([]byte, error) {
+	c := &Client{bin: "tmux", run: func(context.Context, string, ...string) ([]byte, error) {
 		return nil, &exec.ExitError{Stderr: []byte("failed to connect to server")}
-	}
-	t.Cleanup(func() { runCommand = oldRun })
+	}}
 
-	c := &Client{bin: "tmux"}
 	panes, err := c.listPanes(context.Background())
 	if err != nil {
 		t.Fatalf("listPanes returned error: %v", err)

--- a/internal/tmux/list.go
+++ b/internal/tmux/list.go
@@ -11,18 +11,10 @@ import (
 	"time"
 )
 
-var runCommand = func(ctx context.Context, bin string, args ...string) ([]byte, error) {
-	cmd := execCommand(ctx, bin, args...)
-	if cmd == nil {
-		return nil, fmt.Errorf("execCommand returned nil")
-	}
-	return cmd.Output()
-}
-
 // listSessions shells out to tmux to enumerate sessions and translate them
 // into typed Session values.
 func (c *Client) listSessions(ctx context.Context) ([]Session, error) {
-	out, err := runCommand(ctx, c.bin, "list-sessions", "-F", "#{session_id}\t#{session_name}\t#{session_attached}\t#{session_created}\t#{session_activity}")
+	out, err := c.runTmux(ctx, "list-sessions", "-F", "#{session_id}\t#{session_name}\t#{session_attached}\t#{session_created}\t#{session_activity}")
 	if err != nil {
 		if isNoServerError(err) {
 			return []Session{}, nil
@@ -67,7 +59,7 @@ func (c *Client) listSessions(ctx context.Context) ([]Session, error) {
 // listWindows retrieves every window in every session so we can later nest
 // panes under them.
 func (c *Client) listWindows(ctx context.Context) ([]Window, error) {
-	out, err := runCommand(ctx, c.bin, "list-windows", "-a", "-F", "#{session_id}\t#{window_id}\t#{window_index}\t#{window_name}\t#{window_active}\t#{window_last_flag}")
+	out, err := c.runTmux(ctx, "list-windows", "-a", "-F", "#{session_id}\t#{window_id}\t#{window_index}\t#{window_name}\t#{window_active}\t#{window_last_flag}")
 	if err != nil {
 		if isNoServerError(err) {
 			return []Window{}, nil
@@ -124,7 +116,7 @@ func (c *Client) listPanes(ctx context.Context) ([]Pane, error) {
 		"#{pane_dead_status}",
 	}, "\t")
 
-	out, err := runCommand(ctx, c.bin, "list-panes", "-a", "-F", format)
+	out, err := c.runTmux(ctx, "list-panes", "-a", "-F", format)
 	if err != nil {
 		if isNoServerError(err) {
 			return []Pane{}, nil


### PR DESCRIPTION
## Summary

- replace package-global command stubs with per-client dependency injection so parallel tmux tests cannot race
- add the race detector to CI to keep the regression covered
- update `golangci-lint-action` from v9.2.1 to v9.3.0

## Root cause

Parallel tests reassigned and restored the same package-global `runCommand` function. Their writes raced with each other and with list calls reading the function. The test seam now belongs to each `Client`, while production clients keep the real command runner.

Provenance: introduced by commit `c52355ca` on 2025-11-05 when the parallel no-server tests and global stubs were added.

## Proof

- `go test -race ./internal/tmux -count=20`
- `go test -race ./...`
- `go test ./...`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --timeout=5m`
- `govulncheck ./...`
- `go run mvdan.cc/gofumpt@v0.10.0 -l .`
- `goreleaser check`
- CGO-disabled builds for darwin/linux/windows on amd64/arm64
- built binary `--version` and `--dump` against a real temporary tmux session
- autoreview: clean; no accepted/actionable findings

No changelog entry: runtime behavior is unchanged; this fixes the test seam and CI coverage.
