### PR TITLE
build: update nixpkgs lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1778443072,
-        "narHash": "sha256-zi7/fsqM/kFdNuED//4WOCUtezGtKKqRNORjMvfwjnA=",
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "da5ad661ba4e5ef59ba743f0d112cbc30e474f32",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -27,7 +27,7 @@
 
             src = ./.;
 
-            vendorHash = "sha256-Kad31OpV/RA8K1vY7qlBM7t0sA2R/Z7UWFANnpFx8i8=";
+            vendorHash = "sha256-qozRmgemVX+5ye9h0udTi3zBMHMw05RjvFpxyUgqwzI=";
 
             subPackages = [ "cmd/tmuxwatch" ];
 


### PR DESCRIPTION
## Summary

- advance the `nixos-unstable` lock from the 2026-05-10 revision to the 2026-06-29 revision
- refresh the `buildGoModule` vendor hash for the updated nixpkgs/Go toolchain

Upstream revision: https://github.com/NixOS/nixpkgs/commit/b5aa0fbd538984f6e3d201be0005b4463d8b09f8

## Proof

- `nix flake check --print-build-logs` in the official Nix container
- `nix build .#packages.x86_64-linux.default --no-link --print-build-logs`
- Nix package build completed with Go 1.26.4; package check phase passed
- `go test ./...`
- autoreview clean: no accepted/actionable findings

No changelog entry: this is packaging/dependency maintenance with no product behavior change.
