### PR TITLE
build: update Go 1.25 patch release

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/steipete/tmuxwatch
 
-go 1.25.3
+go 1.25.11
 
 require (
 	charm.land/bubbles/v2 v2.1.0


### PR DESCRIPTION
## Summary

- update the Go 1.25 patch baseline from 1.25.3 to 1.25.11
- retain Go 1.25 language compatibility while picking up all supported security and bug fixes through June 2026

Official release history: https://go.dev/doc/devel/release#go1.25.11

## Proof

- `GOTOOLCHAIN=go1.25.11 go version`
- `GOTOOLCHAIN=go1.25.11 go mod tidy` (no module graph changes)
- `GOTOOLCHAIN=go1.25.11 go test -race ./...`
- exact-toolchain golangci-lint v2.12.2
- `govulncheck ./...`: no vulnerabilities found
- CGO-disabled builds for darwin/linux/windows on amd64/arm64
- built binary `--version` and `--dump` against a real temporary tmux session
- Nix flake check and x86_64-linux package build/test remain green
- autoreview clean: no accepted/actionable findings

No changelog entry: this is a patch-level build/security baseline update with no product behavior change.
